### PR TITLE
fix: update bazel target from repo.doc_extract to doc.doc_extract in CI

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: "Test"
-        run: "bazel test --test_output=errors //... //:repo.doc_extract"
+        run: "bazel test --test_output=errors //... //:doc.doc_extract"
       - name: Bump version and push tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.2


### PR DESCRIPTION
The Bazel command in `.github/workflows/tag-and-release.yml` was failing because the `//:repo.doc_extract` target didn't exist. It has been updated to `//:doc.doc_extract` which is the correct target defined by `bzl_library` in `BUILD.bazel`.

---
*PR created automatically by Jules for task [8582366500274745332](https://jules.google.com/task/8582366500274745332) started by @filmil*